### PR TITLE
Remove PHP version check from Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "magenerds/categoryproductlink",
   "description": "This module adds a link from category edit view to category's products",
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0",
     "magento/framework": "100.1.*",
     "magenerds/dashboard": "^1.0"
   },


### PR DESCRIPTION
I guess this is just old but doesn't have any specific need for these PHP versions?

Any chance of removing this check if it's not needed please?